### PR TITLE
Fix API base URL path

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,1 +1,2 @@
-export const BASE_API_URL = 'https://backendsoulbeats-ggeed4cthbcxf9a5.brazilsouth-01.azurewebsites.net/';
+export const BASE_API_URL =
+  'https://backendsoulbeats-ggeed4cthbcxf9a5.brazilsouth-01.azurewebsites.net';


### PR DESCRIPTION
## Summary
- remove trailing slash from API base url to avoid `//` in requests

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684a8efd08f48325a510a44d2bb026f1