### PR TITLE
Remove duplicate config and centralize backend URL

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,0 @@
-const config = {
-  backendUrl: "http://tu-backend.com/api",
-};
-
-export default config;

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,1 +1,2 @@
-export const BASE_API_URL = "https://backendsoulbeats-ggeed4cthbcxf9a5.brazilsouth-01.azurewebsites.net";
+// Base URL for backend API obtained from environment variables
+export const BASE_API_URL = import.meta.env.VITE_BACKEND_URL;

--- a/src/services/backendService.ts
+++ b/src/services/backendService.ts
@@ -1,5 +1,5 @@
-// Obtiene la URL base desde las variables de entorno de Vite
-const BASE_API_URL = import.meta.env.VITE_BACKEND_URL;
+// Base URL is centralized in src/config/config.ts
+import { BASE_API_URL } from '../config/config';
 
 /**
  * Obtiene la información del usuario desde el backend.


### PR DESCRIPTION
## Summary
- keep `src/config/config.ts` as single config source
- remove redundant `src/config.ts`
- use env-based URL exported from config
- update backend service to import the URL constant

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68567300f4388325b4694881a1df75b4