### PR TITLE
Add dark mode

### DIFF
--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -149,23 +149,24 @@ export function Login() {
         setError('Error desconocido al iniciar sesión con Google.');
       }
     }
-  };return (
-    <div className="w-full min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-fuchsia-50 to-pink-50 p-4">
+  };
+  return (
+    <div className="w-full min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-fuchsia-50 to-pink-50 dark:from-gray-900 dark:to-gray-800 p-4">
       <div className="w-full max-w-md">
-        <div className="bg-white shadow-2xl rounded-xl p-8 md:p-12">
+        <div className="bg-white dark:bg-gray-800 shadow-2xl rounded-xl p-8 md:p-12">
           <div className="flex flex-col items-center mb-8">
             <HeartIcon className="w-12 h-12 text-fuchsia-600 mb-3" />
             <h1 className="text-3xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-fuchsia-600 to-pink-600">
               {isRegistering ? 'Crea una cuenta' : 'Explora y Conecta'}
             </h1>
-            <p className="text-gray-600 mt-1">
+            <p className="text-gray-600 dark:text-gray-300 mt-1">
               {isRegistering ? '¡Únete a nosotros hoy!' : '¡Bienvenido de nuevo!'}
             </p>
           </div>
 
           <form onSubmit={handleSubmit} className="space-y-6">
             <div>
-              <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
+              <label htmlFor="email" className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">
                 Correo electrónico
               </label>
               <input
@@ -173,20 +174,20 @@ export function Login() {
                 type="email"
                 required
                 value={email}                onChange={(e) => setEmail(e.target.value)}
-                className="appearance-none block w-full px-4 py-3 border border-gray-300 rounded-lg shadow-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-fuchsia-500 focus:border-fuchsia-500 sm:text-sm transition-colors"
+                className="appearance-none block w-full px-4 py-3 border border-gray-300 dark:border-gray-700 rounded-lg shadow-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-fuchsia-500 focus:border-fuchsia-500 sm:text-sm transition-colors"
                 placeholder="tucorreo@ejemplo.com"
               />
             </div>
 
             <div className="relative">
-              <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
+              <label htmlFor="password" className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">
                 Contraseña
               </label>              <input
                 id="password"
                 type={showPassword ? 'text' : 'password'}
                 required
                 value={password}                onChange={(e) => setPassword(e.target.value)}
-                className="appearance-none block w-full px-4 py-3 border border-gray-300 rounded-lg shadow-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-fuchsia-500 focus:border-fuchsia-500 sm:text-sm transition-colors pr-10"
+                className="appearance-none block w-full px-4 py-3 border border-gray-300 dark:border-gray-700 rounded-lg shadow-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-fuchsia-500 focus:border-fuchsia-500 sm:text-sm transition-colors pr-10"
                 placeholder="••••••••"
               />
               <button
@@ -202,14 +203,14 @@ export function Login() {
 
             {isRegistering && (
               <div className="relative">
-                <label htmlFor="confirmPassword" className="block text-sm font-medium text-gray-700 mb-1">
+                <label htmlFor="confirmPassword" className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">
                   Repite tu contraseña
                 </label>
                 <input
                   id="confirmPassword"
                   type={showConfirmPassword ? 'text' : 'password'}
                   required
-                  value={confirmPassword}                  onChange={(e) => setConfirmPassword(e.target.value)}                  className="appearance-none block w-full px-4 py-3 border border-gray-300 rounded-lg shadow-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-fuchsia-500 focus:border-fuchsia-500 sm:text-sm transition-colors pr-10"
+                  value={confirmPassword}                  onChange={(e) => setConfirmPassword(e.target.value)}                  className="appearance-none block w-full px-4 py-3 border border-gray-300 dark:border-gray-700 rounded-lg shadow-sm placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-fuchsia-500 focus:border-fuchsia-500 sm:text-sm transition-colors pr-10"
                   placeholder="••••••••"
                   onPaste={(e) => e.preventDefault()}
                 />
@@ -226,7 +227,7 @@ export function Login() {
             )}
 
             {error && (
-              <p className="text-sm text-red-600 bg-red-100 p-2 rounded-md text-center">
+              <p className="text-sm text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-900 p-2 rounded-md text-center">
                 {error}
               </p>
             )}
@@ -241,7 +242,7 @@ export function Login() {
             </div>
           </form>
 
-          <div className="mt-8 text-center">            <p className="text-sm text-gray-600">
+          <div className="mt-8 text-center">            <p className="text-sm text-gray-600 dark:text-gray-300">
               {isRegistering ? '¿Ya tienes una cuenta?' : '¿No tienes una cuenta?'}{' '}              <button
                 type="button"
                 onClick={() => setIsRegistering(!isRegistering)}
@@ -253,7 +254,7 @@ export function Login() {
           </div>
         </div>
       </div>
-      <footer className="text-center mt-8 text-gray-600 text-sm">
+      <footer className="text-center mt-8 text-gray-600 dark:text-gray-400 text-sm">
         <p>&copy; {new Date().getFullYear()} SoulBeats</p>
       </footer>
     </div>

--- a/src/components/shared/OutlineButton.tsx
+++ b/src/components/shared/OutlineButton.tsx
@@ -13,7 +13,7 @@ export const OutlineButton: React.FC<OutlineButtonProps> = ({
 }) => {  return (
     <button
       type={type}
-      className={`w-full flex justify-center items-center py-2.5 sm:py-3 px-3 sm:px-4 border border-fuchsia-500 rounded-lg shadow-sm text-sm sm:text-base font-medium text-fuchsia-600 bg-white hover:bg-fuchsia-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-fuchsia-500 transition-all duration-150 ease-in-out transform hover:scale-105 active:scale-95 ${
+      className={`w-full flex justify-center items-center py-2.5 sm:py-3 px-3 sm:px-4 border border-fuchsia-500 dark:border-fuchsia-400 rounded-lg shadow-sm text-sm sm:text-base font-medium text-fuchsia-600 dark:text-fuchsia-400 bg-white dark:bg-gray-800 hover:bg-fuchsia-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-fuchsia-500 transition-all duration-150 ease-in-out transform hover:scale-105 active:scale-95 ${
         disabled ? 'opacity-50 cursor-not-allowed' : ''
       }`}
       onClick={onClick}

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,0 +1,46 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react'
+
+interface ThemeContextProps {
+  darkMode: boolean
+  toggleDarkMode: () => void
+}
+
+const ThemeContext = createContext<ThemeContextProps | undefined>(undefined)
+
+export const useTheme = (): ThemeContextProps => {
+  const context = useContext(ThemeContext)
+  if (!context) {
+    throw new Error('useTheme must be used within ThemeProvider')
+  }
+  return context
+}
+
+export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [darkMode, setDarkMode] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('theme')
+      if (stored) return stored === 'dark'
+      return window.matchMedia('(prefers-color-scheme: dark)').matches
+    }
+    return false
+  })
+
+  useEffect(() => {
+    const root = document.documentElement
+    if (darkMode) {
+      root.classList.add('dark')
+      localStorage.setItem('theme', 'dark')
+    } else {
+      root.classList.remove('dark')
+      localStorage.setItem('theme', 'light')
+    }
+  }, [darkMode])
+
+  const toggleDarkMode = () => setDarkMode((prev) => !prev)
+
+  return (
+    <ThemeContext.Provider value={{ darkMode, toggleDarkMode }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,12 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
+import { ThemeProvider } from './context/ThemeContext'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </StrictMode>,
 )

--- a/src/pages/ExampleRevisionPage.tsx
+++ b/src/pages/ExampleRevisionPage.tsx
@@ -83,14 +83,14 @@ const ExampleRevisionPage: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-fuchsia-50 via-pink-50 to-purple-50 py-6 px-4">
+    <div className="min-h-screen bg-gradient-to-br from-fuchsia-50 via-pink-50 to-purple-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-700 py-6 px-4">
       <div className="max-w-md mx-auto">
-        <h1 className="text-2xl font-bold text-center text-gray-800 mb-6">
+        <h1 className="text-2xl font-bold text-center text-gray-800 dark:text-gray-200 mb-6">
           Componentes Revisados
         </h1>
         
         <div className="text-center mb-4">
-          <span className="text-sm text-gray-600">
+          <span className="text-sm text-gray-600 dark:text-gray-400">
             Perfil {currentProfileIndex + 1} de {sampleProfiles.length}
           </span>
         </div>
@@ -108,16 +108,16 @@ const ExampleRevisionPage: React.FC = () => {
         />
 
         {/* Instructions */}
-        <div className="mt-8 p-4 bg-white/80 backdrop-blur rounded-xl shadow-lg">
-          <h3 className="text-base font-semibold text-gray-800 mb-2">
+        <div className="mt-8 p-4 bg-white/80 dark:bg-gray-800/80 backdrop-blur rounded-xl shadow-lg">
+          <h3 className="text-base font-semibold text-gray-800 dark:text-gray-200 mb-2">
             Componentes Implementados:
           </h3>
-          <ul className="text-xs text-gray-600 space-y-1">
+          <ul className="text-xs text-gray-600 dark:text-gray-400 space-y-1">
             <li>• <span className="font-medium text-fuchsia-600">ProfileCard</span>: Tarjeta de perfil compacta</li>
             <li>• <span className="font-medium text-fuchsia-600">ActionButtons</span>: Botones de acción optimizados</li>
             <li>• <span className="font-medium text-fuchsia-600">MatchModal</span>: Modal de match</li>
           </ul>
-          <div className="mt-3 text-xs text-gray-500">
+          <div className="mt-3 text-xs text-gray-500 dark:text-gray-400">
             ✨ Colores fuchsia/rosa, textos en español y responsivo
           </div>
         </div>
@@ -126,7 +126,7 @@ const ExampleRevisionPage: React.FC = () => {
         <div className="mt-4 text-center">
           <button
             onClick={() => setCurrentProfileIndex(0)}
-            className="px-4 py-2 text-xs bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-lg transition-colors duration-200"
+            className="px-4 py-2 text-xs bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-200 rounded-lg transition-colors duration-200"
           >
             Reiniciar Demo
           </button>

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -2,12 +2,12 @@ import { Login } from '../components/login/Login';
 
 export function LoginPage() {
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="min-h-screen flex flex-col dark:bg-gray-900">
       <header className="flex-shrink-0 bg-gradient-to-r from-fuchsia-600 to-pink-600 text-white py-4 shadow-lg">        <h1 className="text-center text-2xl font-bold">
           Bienvenido a SoulBeats
         </h1>
       </header>
-      <main className="flex-grow flex items-center justify-center bg-gradient-to-br from-fuchsia-50 to-pink-50">
+      <main className="flex-grow flex items-center justify-center bg-gradient-to-br from-fuchsia-50 to-pink-50 dark:from-gray-900 dark:to-gray-800">
         <Login />
       </main>
       <footer className="flex-shrink-0 bg-gradient-to-r from-fuchsia-600 to-pink-600 text-white py-4 text-center text-sm">

--- a/src/pages/UserHomeScreen.tsx
+++ b/src/pages/UserHomeScreen.tsx
@@ -8,17 +8,17 @@ const UserHomeScreen: React.FC = () => {
   const { user } = useAuth();
 
   return (
-    <div className="min-h-full bg-gradient-to-br from-fuchsia-50 to-pink-50">
+    <div className="min-h-full bg-gradient-to-br from-fuchsia-50 to-pink-50 dark:from-gray-900 dark:to-gray-800">
       <div className="flex flex-col items-center justify-center min-h-[calc(100vh-80px)] px-4 py-8">
         <div className="w-full max-w-sm mx-auto space-y-6">
           <div className="text-center">
             <div className="mx-auto mb-4 h-24 w-24 sm:h-28 sm:w-28 rounded-full bg-gradient-to-br from-fuchsia-100 to-pink-100 flex items-center justify-center text-fuchsia-500">
               <UserCircle2 size={56} strokeWidth={1.5} className="sm:w-16 sm:h-16" />
             </div>
-            <h2 className="text-xl sm:text-2xl font-semibold text-gray-800 mb-2">
+            <h2 className="text-xl sm:text-2xl font-semibold text-gray-800 dark:text-gray-200 mb-2">
               {user?.displayName || user?.email || 'Usuario'}
             </h2>
-            <p className="text-sm text-gray-500">
+            <p className="text-sm text-gray-500 dark:text-gray-400">
               Gestiona tu perfil y conecta tus servicios.
             </p>
           </div>

--- a/src/router/AppRouter.tsx
+++ b/src/router/AppRouter.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Moon, Sun } from 'lucide-react';
 import {
   BrowserRouter as Router,
   Routes,
@@ -13,17 +14,19 @@ import UserHomeScreen from '../pages/UserHomeScreen';
 import ExampleRevisionPage from '../pages/ExampleRevisionPage';
 import ProtectedRoute from './ProtectedRoute';
 import { useAuth } from '../context/AuthContext';
+import { useTheme } from '../context/ThemeContext';
 
 const AppRouter: React.FC = () => {
   const { user, loading, logout } = useAuth();
+  const { darkMode, toggleDarkMode } = useTheme();
 
   // Mostrar loading mientras se verifica el estado de autenticación
   if (loading) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-fuchsia-50 to-pink-50">
+      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-fuchsia-50 to-pink-50 dark:from-gray-900 dark:to-gray-800">
         <div className="text-center">
           <div className="animate-spin rounded-full h-16 w-16 border-b-2 border-fuchsia-600 mx-auto mb-4"></div>
-          <p className="text-gray-600 text-lg">Cargando...</p>
+          <p className="text-gray-600 dark:text-gray-300 text-lg">Cargando...</p>
         </div>
       </div>
     );
@@ -31,7 +34,8 @@ const AppRouter: React.FC = () => {
 
   return (
     <Router>
-      <div className="App min-h-screen flex flex-col">        {user && (
+      <div className="App min-h-screen flex flex-col dark:bg-gray-900">
+        {user && (
           <nav className="flex-shrink-0 bg-gradient-to-r from-fuchsia-600 to-pink-600 text-white py-3 sm:py-4 shadow-lg">
             <div className="max-w-6xl mx-auto px-3 sm:px-4">
               <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center space-y-3 sm:space-y-0">
@@ -90,6 +94,13 @@ const AppRouter: React.FC = () => {
                   <span className="text-white/90 text-xs sm:text-sm text-center sm:text-left">
                     Bienvenido, {user.email?.split('@')[0] || user.email}
                   </span>
+                  <button
+                    onClick={toggleDarkMode}
+                    className="p-2 bg-white/10 hover:bg-white/20 text-white border border-white/30 hover:border-white/50 rounded-lg transition-colors"
+                    aria-label="Toggle dark mode"
+                  >
+                    {darkMode ? <Sun size={18} /> : <Moon size={18} />}
+                  </button>
                   <button
                     onClick={logout}
                     className="px-3 sm:px-4 py-1.5 sm:py-2 bg-white/10 hover:bg-white/20 text-white border border-white/30 hover:border-white/50 rounded-lg font-medium transition-all duration-200 text-sm sm:text-base"

--- a/src/router/ProtectedRoute.tsx
+++ b/src/router/ProtectedRoute.tsx
@@ -13,10 +13,10 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
   // Mostrar un spinner o loading mientras se verifica la autenticación
   if (loading) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-fuchsia-50 to-pink-50">
+      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-fuchsia-50 to-pink-50 dark:from-gray-900 dark:to-gray-800">
         <div className="text-center">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-fuchsia-600 mx-auto mb-4"></div>
-          <p className="text-gray-600">Cargando...</p>
+          <p className="text-gray-600 dark:text-gray-300">Cargando...</p>
         </div>
       </div>
     );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+export default {
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
## Summary
- enable Tailwind dark mode via config
- add ThemeProvider to manage theme and save preference
- update navigation bar with a sun/moon toggle
- adapt several pages/components with dark styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bda54c4f48325b94f3e6c70acdf89